### PR TITLE
Unfreeze run dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,10 +20,10 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - aiohttp >=3.3.1
-    - aioitertools >=0.5.1
-    - botocore >=1.24.21,<1.24.22
-    - wrapt >=1.10.10
+    - aiohttp
+    - aioitertools
+    - botocore
+    - wrapt
 
 test:
   imports:


### PR DESCRIPTION
`botocore` version was incorrect and it makes no sense to keep it up-to-date, because it can be done only manually.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
