### PR TITLE
fix: relax botocore restriction

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 0b095af50da2d6f94e93ca959e2a4876f0f0d84d534b61b21d8e050832d04ab6
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -22,7 +22,7 @@ requirements:
     - python >=3.8
     - aiohttp >=3.7.4.post0,<4.0.0
     - aioitertools >=0.5.1,<1.0.0
-    - botocore >=1.33.2,<1.33.14
+    - botocore >=1.33.2,<1.34.28
     - wrapt >=1.10.10,<2.0.0
 
 test:


### PR DESCRIPTION
The release of 2.11.1 included changes to the dependency version
requirements [1]. So the feedstock needs to also reflect this change.

1. https://github.com/aio-libs/aiobotocore/pull/1079

Signed-off-by: Ismayil Mirzali <ismayil.mirzali@estafet.com>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
