### PR TITLE
Update urllib3 deps to allow python3.10+ urlllib3-2 dep to resolve.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 552d5756989621b5274f1b4a4840cd76ae83dd930d0b1839af6443743a893faf
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -27,7 +27,10 @@ requirements:
     - python-dateutil >=2.1,<3.0.0
     - jmespath >=0.7.1,<2.0.0
     - multidict >=6.0.0,<7.0.0
-    - urllib3 >=1.25.4,<1.27
+    # https://github.com/boto/botocore/pull/3034
+    - urllib3 >=1.25.4,<1.27       # [not python_geq_310]
+    # https://github.com/boto/botocore/pull/3141
+    - urllib3 >=1.25.4,!=2.2.0,<3  # [python_geq_310]
     - wrapt >=1.10.10,<2.0.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,9 +27,9 @@ requirements:
     - python-dateutil >=2.1,<3.0.0
     - jmespath >=0.7.1,<2.0.0
     - multidict >=6.0.0,<7.0.0
-    # c/f noarch means no selectors, so a 'naked' dep that is more
-    # fully specified by botocore
-    - urllib3
+    # c/f noarch means no selectors, so the least restrictive
+    # urllib3 dep is specified here
+    - urllib3 >=1.25.4,!=2.2.0,<3
     - wrapt >=1.10.10,<2.0.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,8 @@ requirements:
     - python-dateutil >=2.1,<3.0.0
     - jmespath >=0.7.1,<2.0.0
     - multidict >=6.0.0,<7.0.0
-    # https://github.com/boto/botocore/pull/3034
-    - urllib3 >=1.25.4,<1.27       # [not python_geq_310]
-    # https://github.com/boto/botocore/pull/3141
-    - urllib3 >=1.25.4,!=2.2.0,<3  # [python_geq_310]
+    # urllib3 is not included, but transiently provided
+    # by botocore
     - wrapt >=1.10.10,<2.0.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,9 @@ requirements:
     - python-dateutil >=2.1,<3.0.0
     - jmespath >=0.7.1,<2.0.0
     - multidict >=6.0.0,<7.0.0
-    # urllib3 is not included, but transiently provided
-    # by botocore
+    # c/f noarch means no selectors, so a 'naked' dep that is more
+    # fully specified by botocore
+    - urllib3
     - wrapt >=1.10.10,<2.0.0
 
 test:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

@conda-forge-admin please rerender

The `urllib3` dep on this repo is very tight. I believe it can be updated to match what [botocore does](https://github.com/conda-forge/botocore-feedstock/blob/main/recipe/meta.yaml#L31C1-L34C54) and what [upstream shows](https://github.com/aio-libs/aiobotocore/blob/master/pyproject.toml#L39-L40).  Thank you for the consideration.