### PR TITLE
Convert aiobotocore-feedstock to v1 feedstock

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -57,20 +67,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ Summary: Async client for aws services using botocore and aiohttp
 
 Development: https://github.com/aio-libs/aiobotocore
 
-Documentation: http://aiobotocore.readthedocs.io
+Documentation: http://aiobotocore.readthedocs.io/
 
 Main purpose of this library to support amazon s3 api, but other services
 should work (may be with minor fixes). For now it has been tested only for
 upload/download api for s3. It has been reported that SQS and Dynamo
 services also work.
-
 
 Current build status
 ====================

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,3 +6,5 @@ conda_build:
   pkg_format: '2'
 bot:
   inspection: update-grayskull
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,53 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
+[project]
+name = "aiobotocore-feedstock"
+version = "3.51.1"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/aiobotocore-feedstock"
+authors = ["@conda-forge/aiobotocore"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build aiobotocore-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build aiobotocore-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of aiobotocore-feedstock packages built for variant linux_64_"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,26 +1,29 @@
-{% set name = "aiobotocore" %}
-{% set version = "2.23.2" %}
+schema_version: 1
+
+context:
+  name: aiobotocore
+  version: 2.23.2
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
   sha256: 9c2cbd6e813bb6c60b7f20fc11897976a583c57b0093a87bebfe80a9b08746b2
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - pip
     - setuptools >=68.2.0
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     - aiohttp >=3.9.2,<4.0.0
     - aioitertools >=0.5.1,<1.0.0
     - botocore >=1.39.7,<1.39.9
@@ -29,19 +32,20 @@ requirements:
     - multidict >=6.0.0,<7.0.0
     - wrapt >=1.10.10,<2.0.0
 
-test:
-  imports:
-    - aiobotocore
-  commands:
-    - pip check
-  requires:
-    - pip
-    - python {{ python_min }}
+tests:
+  - python:
+      imports:
+        - aiobotocore
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - pip check
 
 about:
-  home: https://github.com/aio-libs/aiobotocore
   license: Apache-2.0
-  license_family: Apache
   license_file: LICENSE
   summary: Async client for aws services using botocore and aiohttp
   description: |
@@ -49,8 +53,9 @@ about:
     should work (may be with minor fixes). For now it has been tested only for
     upload/download api for s3. It has been reported that SQS and Dynamo
     services also work.
-  doc_url: http://aiobotocore.readthedocs.io
-  dev_url: https://github.com/aio-libs/aiobotocore
+  homepage: https://github.com/aio-libs/aiobotocore
+  repository: https://github.com/aio-libs/aiobotocore
+  documentation: http://aiobotocore.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This PR converts aiobotocore-feedstock to a v1 recipe and switch the conda build tool to rattler-build.
It has been automatically generated with [feedrattler v0.3.13](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [ ] Ensured the license file is being packaged.
